### PR TITLE
Added option to retrieve configuration from SSM parameter store

### DIFF
--- a/cmd/deployman/main.go
+++ b/cmd/deployman/main.go
@@ -99,7 +99,7 @@ func main() {
 		logger.Fatal("🚨 Command Failure", err)
 	}
 
-	deployConfig, err := internal.NewConfig(*config)
+	deployConfig, err := internal.NewConfig(ctx, awsClient, *config)
 	if err != nil {
 		logger.Fatal("🚨 Command Failure", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.18.22
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.29.1
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.33.1
 	github.com/aws/smithy-go v1.13.4
 	github.com/go-playground/validator/v10 v10.11.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.19 h1:piDBAaWkaxkkV
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.19/go.mod h1:BmQWRVkLTmyNzYPFAZgon53qKLWBNSvonugD1MrSWUs=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.29.1 h1:/EMdFPW/Ppieh0WUtQf1+qCGNLdsq5UWUyevBQ6vMVc=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.29.1/go.mod h1:/NHbqPRiwxSPVOB2Xr+StDEH+GWV/64WwnUjv4KYzV0=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.33.1 h1:N4aPQGoAgdUr+3F1UcuW8/WE3aM7sxzOpzDP0hWkJCg=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.33.1/go.mod h1:rEsqsZrOp9YvSGPOrcL3pR9+i/QJaWRkAYbuxMa7yCU=
 github.com/aws/aws-sdk-go-v2/service/sso v1.11.25 h1:GFZitO48N/7EsFDt8fMa5iYdmWqkUDDB3Eje6z3kbG0=
 github.com/aws/aws-sdk-go-v2/service/sso v1.11.25/go.mod h1:IARHuzTXmj1C0KS35vboR0FeJ89OkEy1M9mWbK2ifCI=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8 h1:jcw6kKZrtNfBPJkaHrscDOZoe5gvi9wjudnxvozYFJo=

--- a/internal/bundler.go
+++ b/internal/bundler.go
@@ -94,7 +94,7 @@ func (b *Bundler) ListBundles(ctx context.Context) error {
 		if len(targets) > 0 {
 			status = "active:[" + strings.Join(targets, ", ") + "]"
 		}
-		location := b.config.TimeZone.GetLocation()
+		location := b.config.TimeZone.CurrentLocation()
 		data = append(data, []string{
 			strconv.Itoa(i + 1),
 			bundleObject.LastModified.In(location).Format(time.RFC3339),
@@ -118,7 +118,7 @@ func (b *Bundler) Register(ctx context.Context, uploadFile string, bundleName st
 		var apiErr smithy.APIError
 		if err != nil {
 			if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NotFound" {
-				if err := b.client.CreateS3Bucket(ctx, b.config.BundleBucket, b.client.GetRegion()); err != nil {
+				if err := b.client.CreateS3Bucket(ctx, b.config.BundleBucket, b.client.Region()); err != nil {
 					return err
 				}
 				if err := b.client.EnableS3BucketVersioning(ctx, b.config.BundleBucket); err != nil {

--- a/test/e2e_awsclient.go
+++ b/test/e2e_awsclient.go
@@ -22,9 +22,8 @@ type MockAwsClient struct {
 	State *TestingState
 }
 
-func (c *MockAwsClient) WithState(state *TestingState) *MockAwsClient {
-	c.State = state
-	return c
+func NewMockAwsClient(state *TestingState) *MockAwsClient {
+	return &MockAwsClient{State: state}
 }
 
 func (c *MockAwsClient) Region() string {

--- a/test/e2e_awsclient.go
+++ b/test/e2e_awsclient.go
@@ -8,6 +8,7 @@ import (
 	albTypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	ssmTypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/givery-technology/deployman/internal"
 	"github.com/pkg/errors"
 	"io"
@@ -18,21 +19,22 @@ import (
 )
 
 type MockAwsClient struct {
-	ctx *TestingState
+	State *TestingState
 }
 
-func NewMockAwsClient(ctx *TestingState) *MockAwsClient {
-	return &MockAwsClient{ctx: ctx}
+func (c *MockAwsClient) WithState(state *TestingState) *MockAwsClient {
+	c.State = state
+	return c
 }
 
-func (m *MockAwsClient) GetRegion() string {
+func (c *MockAwsClient) Region() string {
 	return "us-east-1"
 }
 
-func (m *MockAwsClient) ListS3BucketObjects(_ context.Context, bucket string, prefix string) ([]s3Types.Object, error) {
+func (c *MockAwsClient) ListS3BucketObjects(_ context.Context, bucket string, prefix string) ([]s3Types.Object, error) {
 	var objects []TestingBucketObject
-	if m.ctx.Bucket != nil && *m.ctx.Bucket.Name == bucket {
-		objects = internal.Filter(m.ctx.Bucket.Objects, func(o *TestingBucketObject) bool {
+	if c.State.Bucket != nil && *c.State.Bucket.Name == bucket {
+		objects = internal.Filter(c.State.Bucket.Objects, func(o *TestingBucketObject) bool {
 			return strings.Contains(*o.Key, prefix)
 		})
 	}
@@ -44,18 +46,18 @@ func (m *MockAwsClient) ListS3BucketObjects(_ context.Context, bucket string, pr
 	}), nil
 }
 
-func (m *MockAwsClient) HeadS3Bucket(_ context.Context, bucket string) error {
-	if m.ctx.Bucket == nil {
+func (c *MockAwsClient) HeadS3Bucket(_ context.Context, bucket string) error {
+	if c.State.Bucket == nil {
 		return &s3Types.NotFound{Message: aws.String("BucketNotFound")}
 	}
 	return nil
 }
 
-func (m *MockAwsClient) CreateS3Bucket(_ context.Context, bucket string, _ string) error {
-	if m.ctx.Bucket != nil {
+func (c *MockAwsClient) CreateS3Bucket(_ context.Context, bucket string, _ string) error {
+	if c.State.Bucket != nil {
 		return errors.Errorf("Bucket already exists. bucket:%s", bucket)
 	}
-	m.ctx.Bucket = &TestingBucket{
+	c.State.Bucket = &TestingBucket{
 		Name:                   aws.String(bucket),
 		IsVersioningEnabled:    aws.Bool(false),
 		IsAclPrivated:          aws.Bool(false),
@@ -65,44 +67,44 @@ func (m *MockAwsClient) CreateS3Bucket(_ context.Context, bucket string, _ strin
 	return nil
 }
 
-func (m *MockAwsClient) EnableS3BucketVersioning(_ context.Context, bucket string) error {
-	if m.ctx.Bucket == nil {
+func (c *MockAwsClient) EnableS3BucketVersioning(_ context.Context, bucket string) error {
+	if c.State.Bucket == nil {
 		return errors.Errorf("Bucket not found. bucket:%s", bucket)
 	}
-	m.ctx.Bucket.IsVersioningEnabled = aws.Bool(true)
+	c.State.Bucket.IsVersioningEnabled = aws.Bool(true)
 	return nil
 }
 
-func (m *MockAwsClient) MakeS3BucketAclPrivate(_ context.Context, bucket string) error {
-	if m.ctx.Bucket == nil {
+func (c *MockAwsClient) MakeS3BucketAclPrivate(_ context.Context, bucket string) error {
+	if c.State.Bucket == nil {
 		return errors.Errorf("Bucket not found. bucket:%s", bucket)
 	}
-	m.ctx.Bucket.IsAclPrivated = aws.Bool(true)
+	c.State.Bucket.IsAclPrivated = aws.Bool(true)
 	return nil
 }
 
-func (m *MockAwsClient) DisableS3BucketPublicAccess(_ context.Context, bucket string) error {
-	if m.ctx.Bucket == nil {
+func (c *MockAwsClient) DisableS3BucketPublicAccess(_ context.Context, bucket string) error {
+	if c.State.Bucket == nil {
 		return errors.Errorf("Bucket not found. bucket:%s", bucket)
 	}
-	m.ctx.Bucket.IsPublicAccessDisabled = aws.Bool(true)
+	c.State.Bucket.IsPublicAccessDisabled = aws.Bool(true)
 	return nil
 }
 
-func (m *MockAwsClient) DeleteS3BucketObject(_ context.Context, bucket string, key string) error {
+func (c *MockAwsClient) DeleteS3BucketObject(_ context.Context, bucket string, key string) error {
 	var objects []TestingBucketObject
-	if m.ctx.Bucket != nil && *m.ctx.Bucket.Name == bucket {
-		objects = internal.Filter(m.ctx.Bucket.Objects, func(o *TestingBucketObject) bool {
+	if c.State.Bucket != nil && *c.State.Bucket.Name == bucket {
+		objects = internal.Filter(c.State.Bucket.Objects, func(o *TestingBucketObject) bool {
 			return strings.Contains(*o.Key, key)
 		})
 	}
-	m.ctx.Bucket.Objects = internal.FastDelete(objects, func(o *TestingBucketObject) bool {
+	c.State.Bucket.Objects = internal.FastDelete(objects, func(o *TestingBucketObject) bool {
 		return *o.Key == key
 	})
 	return nil
 }
 
-func (m *MockAwsClient) PutS3BucketObjectAsBinaryFile(_ context.Context, bucket string, key string, file *os.File) error {
+func (c *MockAwsClient) PutS3BucketObjectAsBinaryFile(_ context.Context, bucket string, key string, file *os.File) error {
 	defer func(file *os.File) {
 		_ = file.Close()
 	}(file)
@@ -110,8 +112,8 @@ func (m *MockAwsClient) PutS3BucketObjectAsBinaryFile(_ context.Context, bucket 
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if m.ctx.Bucket != nil {
-		m.ctx.Bucket.Objects = append(m.ctx.Bucket.Objects, TestingBucketObject{
+	if c.State.Bucket != nil {
+		c.State.Bucket.Objects = append(c.State.Bucket.Objects, TestingBucketObject{
 			LastModified: aws.Time(time.Now()),
 			Key:          aws.String(key),
 			Value:        buf,
@@ -120,9 +122,9 @@ func (m *MockAwsClient) PutS3BucketObjectAsBinaryFile(_ context.Context, bucket 
 	return nil
 }
 
-func (m *MockAwsClient) PutS3BucketObjectAsTextFile(_ context.Context, bucket string, key string, value string) error {
-	if m.ctx.Bucket != nil {
-		m.ctx.Bucket.Objects = append(m.ctx.Bucket.Objects, TestingBucketObject{
+func (c *MockAwsClient) PutS3BucketObjectAsTextFile(_ context.Context, bucket string, key string, value string) error {
+	if c.State.Bucket != nil {
+		c.State.Bucket.Objects = append(c.State.Bucket.Objects, TestingBucketObject{
 			LastModified: aws.Time(time.Now()),
 			Key:          aws.String(key),
 			Value:        []byte(value),
@@ -132,9 +134,9 @@ func (m *MockAwsClient) PutS3BucketObjectAsTextFile(_ context.Context, bucket st
 	return nil
 }
 
-func (m *MockAwsClient) GetS3BucketObject(_ context.Context, bucket string, key string) (*s3.GetObjectOutput, error) {
-	if m.ctx.Bucket != nil && *m.ctx.Bucket.Name == bucket {
-		object := internal.FirstOrNil(m.ctx.Bucket.Objects, func(o *TestingBucketObject) bool {
+func (c *MockAwsClient) GetS3BucketObject(_ context.Context, bucket string, key string) (*s3.GetObjectOutput, error) {
+	if c.State.Bucket != nil && *c.State.Bucket.Name == bucket {
+		object := internal.FirstOrNil(c.State.Bucket.Objects, func(o *TestingBucketObject) bool {
 			return strings.Contains(*o.Key, key)
 		})
 		if object != nil {
@@ -148,11 +150,11 @@ func (m *MockAwsClient) GetS3BucketObject(_ context.Context, bucket string, key 
 	return nil, errors.Errorf("Bucket object not found. bucket:%s, key:%s", bucket, key)
 }
 
-func (m *MockAwsClient) GetALBListenerRule(_ context.Context, listenerRuleArn string) (*albTypes.Rule, error) {
-	if *m.ctx.LoadBalancer.ListenerRuleArn != listenerRuleArn {
+func (c *MockAwsClient) GetALBListenerRule(_ context.Context, listenerRuleArn string) (*albTypes.Rule, error) {
+	if *c.State.LoadBalancer.ListenerRuleArn != listenerRuleArn {
 		return nil, errors.Errorf("ListenerRule not found. listenerRuleArn:%s", listenerRuleArn)
 	}
-	targetGroups := internal.Map(m.ctx.LoadBalancer.TargetGroups, func(_ int, tg *TestingTargetGroup) *albTypes.TargetGroupTuple {
+	targetGroups := internal.Map(c.State.LoadBalancer.TargetGroups, func(_ int, tg *TestingTargetGroup) *albTypes.TargetGroupTuple {
 		return &albTypes.TargetGroupTuple{
 			TargetGroupArn: tg.TargetGroupArn,
 			Weight:         tg.Weight,
@@ -163,18 +165,18 @@ func (m *MockAwsClient) GetALBListenerRule(_ context.Context, listenerRuleArn st
 			{
 				Type: albTypes.ActionTypeEnumForward,
 				ForwardConfig: &albTypes.ForwardActionConfig{
-					TargetGroupStickinessConfig: m.ctx.LoadBalancer.ForwardActionStickness,
+					TargetGroupStickinessConfig: c.State.LoadBalancer.ForwardActionStickness,
 					TargetGroups:                targetGroups,
 				},
 			},
 		},
 		IsDefault: true,
-		RuleArn:   m.ctx.LoadBalancer.ListenerRuleArn,
+		RuleArn:   c.State.LoadBalancer.ListenerRuleArn,
 	}, nil
 }
 
-func (m *MockAwsClient) DescribeALBTargetHealth(_ context.Context, targetGroupArn string) ([]albTypes.TargetHealthDescription, error) {
-	targetGroup := internal.FirstOrNil(m.ctx.LoadBalancer.TargetGroups, func(tg *TestingTargetGroup) bool {
+func (c *MockAwsClient) DescribeALBTargetHealth(_ context.Context, targetGroupArn string) ([]albTypes.TargetHealthDescription, error) {
+	targetGroup := internal.FirstOrNil(c.State.LoadBalancer.TargetGroups, func(tg *TestingTargetGroup) bool {
 		return *tg.TargetGroupArn == targetGroupArn
 	})
 	if targetGroup == nil {
@@ -189,8 +191,8 @@ func (m *MockAwsClient) DescribeALBTargetHealth(_ context.Context, targetGroupAr
 	}), nil
 }
 
-func (m *MockAwsClient) DescribeAutoScalingGroup(_ context.Context, name string) (*asgTypes.AutoScalingGroup, error) {
-	autoScalingGroup := internal.FirstOrNil(m.ctx.AutoScalingGroups, func(g *TestingAutoScalingGroup) bool {
+func (c *MockAwsClient) DescribeAutoScalingGroup(_ context.Context, name string) (*asgTypes.AutoScalingGroup, error) {
+	autoScalingGroup := internal.FirstOrNil(c.State.AutoScalingGroups, func(g *TestingAutoScalingGroup) bool {
 		return *g.AutoScalingGroupName == name
 	})
 	if autoScalingGroup == nil {
@@ -199,8 +201,8 @@ func (m *MockAwsClient) DescribeAutoScalingGroup(_ context.Context, name string)
 	return autoScalingGroup.AutoScalingGroup, nil
 }
 
-func (m *MockAwsClient) DescribeALBTargetGroup(_ context.Context, targetGroupArn string) (*albTypes.TargetGroup, error) {
-	targetGroup := internal.FirstOrNil(m.ctx.LoadBalancer.TargetGroups, func(tg *TestingTargetGroup) bool {
+func (c *MockAwsClient) DescribeALBTargetGroup(_ context.Context, targetGroupArn string) (*albTypes.TargetGroup, error) {
+	targetGroup := internal.FirstOrNil(c.State.LoadBalancer.TargetGroups, func(tg *TestingTargetGroup) bool {
 		return *tg.TargetGroupArn == targetGroupArn
 	})
 	if targetGroup == nil {
@@ -211,14 +213,14 @@ func (m *MockAwsClient) DescribeALBTargetGroup(_ context.Context, targetGroupArn
 	}, nil
 }
 
-func (m *MockAwsClient) ModifyALBListenerRule(_ context.Context, listenerRuleArn string, forwardAction *albTypes.ForwardActionConfig) error {
-	if *m.ctx.LoadBalancer.ListenerRuleArn != listenerRuleArn {
+func (c *MockAwsClient) ModifyALBListenerRule(_ context.Context, listenerRuleArn string, forwardAction *albTypes.ForwardActionConfig) error {
+	if *c.State.LoadBalancer.ListenerRuleArn != listenerRuleArn {
 		return errors.Errorf("ListenerRule not found. listenerRuleArn:%s", listenerRuleArn)
 	}
 	for x := range forwardAction.TargetGroups {
 		from := &forwardAction.TargetGroups[x]
-		for y := range m.ctx.LoadBalancer.TargetGroups {
-			to := &m.ctx.LoadBalancer.TargetGroups[y]
+		for y := range c.State.LoadBalancer.TargetGroups {
+			to := &c.State.LoadBalancer.TargetGroups[y]
 			if *from.TargetGroupArn == *to.TargetGroupArn {
 				*to.TargetGroupTuple = *from
 			}
@@ -227,9 +229,9 @@ func (m *MockAwsClient) ModifyALBListenerRule(_ context.Context, listenerRuleArn
 	return nil
 }
 
-func (m *MockAwsClient) UpdateAutoScalingGroup(_ context.Context, name string, desiredCapacity *int32, minSize *int32, maxSize *int32) error {
-	for i := range m.ctx.AutoScalingGroups {
-		autoScalingGroup := &m.ctx.AutoScalingGroups[i]
+func (c *MockAwsClient) UpdateAutoScalingGroup(_ context.Context, name string, desiredCapacity *int32, minSize *int32, maxSize *int32) error {
+	for i := range c.State.AutoScalingGroups {
+		autoScalingGroup := &c.State.AutoScalingGroups[i]
 		if *autoScalingGroup.AutoScalingGroupName == name {
 			if desiredCapacity != nil {
 				autoScalingGroup.DesiredCapacity = desiredCapacity
@@ -253,8 +255,8 @@ func (m *MockAwsClient) UpdateAutoScalingGroup(_ context.Context, name string, d
 	return nil
 }
 
-func (m *MockAwsClient) DescribeScheduledActions(_ context.Context, name string) ([]asgTypes.ScheduledUpdateGroupAction, error) {
-	autoScalingGroup := internal.FirstOrNil(m.ctx.AutoScalingGroups, func(g *TestingAutoScalingGroup) bool {
+func (c *MockAwsClient) DescribeScheduledActions(_ context.Context, name string) ([]asgTypes.ScheduledUpdateGroupAction, error) {
+	autoScalingGroup := internal.FirstOrNil(c.State.AutoScalingGroups, func(g *TestingAutoScalingGroup) bool {
 		return *g.AutoScalingGroupName == name
 	})
 	if autoScalingGroup == nil {
@@ -263,9 +265,9 @@ func (m *MockAwsClient) DescribeScheduledActions(_ context.Context, name string)
 	return autoScalingGroup.ScheduledActions, nil
 }
 
-func (m *MockAwsClient) PutScheduledUpdateGroupAction(_ context.Context, name string, action *asgTypes.ScheduledUpdateGroupAction) error {
-	for i := range m.ctx.AutoScalingGroups {
-		autoScalingGroup := &m.ctx.AutoScalingGroups[i]
+func (c *MockAwsClient) PutScheduledUpdateGroupAction(_ context.Context, name string, action *asgTypes.ScheduledUpdateGroupAction) error {
+	for i := range c.State.AutoScalingGroups {
+		autoScalingGroup := &c.State.AutoScalingGroups[i]
 		if *autoScalingGroup.AutoScalingGroupName == name {
 			autoScalingGroup.ScheduledActions = append(autoScalingGroup.ScheduledActions, *action)
 		}
@@ -273,9 +275,9 @@ func (m *MockAwsClient) PutScheduledUpdateGroupAction(_ context.Context, name st
 	return nil
 }
 
-func (m *MockAwsClient) DeleteScheduledAction(_ context.Context, autoScalingGroupName string, scheduledActionName string) error {
-	for x := range m.ctx.AutoScalingGroups {
-		autoScalingGroup := &m.ctx.AutoScalingGroups[x]
+func (c *MockAwsClient) DeleteScheduledAction(_ context.Context, autoScalingGroupName string, scheduledActionName string) error {
+	for x := range c.State.AutoScalingGroups {
+		autoScalingGroup := &c.State.AutoScalingGroups[x]
 		if *autoScalingGroup.AutoScalingGroupName == autoScalingGroupName {
 			autoScalingGroup.ScheduledActions = internal.FastDelete(autoScalingGroup.ScheduledActions, func(a *asgTypes.ScheduledUpdateGroupAction) bool {
 				return *a.ScheduledActionName == scheduledActionName
@@ -283,4 +285,14 @@ func (m *MockAwsClient) DeleteScheduledAction(_ context.Context, autoScalingGrou
 		}
 	}
 	return nil
+}
+
+func (c *MockAwsClient) GetSSMParameter(_ context.Context, name string, withDecription bool) (*ssmTypes.Parameter, error) {
+	return &ssmTypes.Parameter{
+		LastModifiedDate: aws.Time(time.Now()),
+		Name:             aws.String("test/parameter/001"),
+		Type:             ssmTypes.ParameterTypeString,
+		Value:            aws.String("TestParameterValue001"),
+		Version:          0,
+	}, nil
 }


### PR DESCRIPTION
In the `--config` option, config is obtained from the SSM parameter store only if it is prefixed with `ssm:`